### PR TITLE
Search all translations for the exact key

### DIFF
--- a/lib/i18n/backend/active_record.rb
+++ b/lib/i18n/backend/active_record.rb
@@ -32,8 +32,8 @@ module I18n
 
           if result.empty?
             nil
-          elsif result.first.key == key
-            result.first.value
+          elsif (matching = result.select { |r| r.key == key }.first)
+            matching.value
           else
             chop_range = (key.size + FLATTEN_SEPARATOR.size)..-1
             result = result.inject({}) do |hash, r|


### PR DESCRIPTION
Mysql returns lower and uppercase matches. If the first result doesn't match(in a case sensitive way) then the code assumes it must return a hash.

Since mysql may return the exact key at the end of the result array we have to check the entire result array for an exact match and only then can we assume a hash should be returned.
